### PR TITLE
Add optional project selector to Add Story form

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ tests_require = [
 ]
 
 install_requires = [
-    'sentry>=5.0.0',
+    'sentry>5.4.5',
     'pyvotal',
 ]
 


### PR DESCRIPTION
The project ID field is now optional. If it is left blank a new dropdown
will appear in the Add Story form allowing a project to be selected.

This change depends on an unreleased change in sentry master, so bump the
dependency to >5.4.5 (the current release).

See: https://github.com/getsentry/sentry/pull/864
